### PR TITLE
Fix color hex in AtomsCanvas story

### DIFF
--- a/app/components/atoms/AtomsCanvas/AtomsCanvas.stories.ts
+++ b/app/components/atoms/AtomsCanvas/AtomsCanvas.stories.ts
@@ -20,7 +20,7 @@ export const MultipleAtoms: Story = {
         atoms: [
             { symbol: 'H', color: '#b3e5fc', x: 0, y: 0, z: 0 },
             { symbol: 'O', color: '#ff8a80', x: 1, y: 1, z: 1 },
-            { symbol: 'C', color: 'bdbdbd', x: -1, y: -1, z: -1 }
+            { symbol: 'C', color: '#bdbdbd', x: -1, y: -1, z: -1 }
         ]
     }
 };


### PR DESCRIPTION
## Summary
- fix the carbon atom color value in AtomsCanvas stories

## Testing
- `npm run build-storybook` *(fails: `storybook: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684defd54d94832b93fc98b2aaa7e58a