### PR TITLE
fix: update GitHub Pages paths

### DIFF
--- a/.github/workflows/deploy_to_github_pages.yml
+++ b/.github/workflows/deploy_to_github_pages.yml
@@ -22,8 +22,8 @@ jobs:
       - run: npm ci
       - run: npm run build
       # GitHub Pages は index.html をルートに置く必要があるので、
-      # molecule_playground/index.html を index.html にリネームしてルートに配置
-      - run: mv build/client/molecule_playground/index.html build/client/index.html
+      # molecule-playground/index.html を index.html にリネームしてルートに配置
+      - run: mv build/client/molecule-playground/index.html build/client/index.html
       - uses: actions/upload-pages-artifact@v3
         with:
           path: build/client       # アーティファクト化

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -2,7 +2,7 @@ import type { Config } from '@react-router/dev/config';
 
 // GitHub Pages deployment requires a specific basename
 export const basename =
-    process.env.GITHUB_ACTIONS === 'true' ? '/molecule_playground/' : '/';
+    process.env.GITHUB_ACTIONS === 'true' ? '/molecule-playground/' : '/';
 
 export default {
     // Config options...


### PR DESCRIPTION
## Summary
- use hyphenated project name in React Router basename
- update GitHub Actions workflow to rename index.html from molecule-playground directory

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d4ae2298c832ba51a73af5d7d42da